### PR TITLE
style: Cargo fmt

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,9 +9,7 @@ const _END_OF_TURN_TOKEN: &str = &"ROBOT:";
 const _TEST_PROMPT: &str = &"A vulnerability was found in Schneider Electric APC Easy UPS Online up to 2 --- A vulnerability, which was classified as critical, was found in Apple Safari up to 15 --- A vulnerability classified as critical was found in D-Link DIR-895 FW102b07 (Router Operating System) --- A vulnerability, which was classified as critical, was found in Microsoft Edge 99 --- A vulnerability classified as problematic was found in Huawei HarmonyOS and EMUI (affected version not known)";
 const USER_IMPERSONATE_PATTERN: &str = r"(?s)USER:\n.+";
 
-#[derive(
-    clap::ValueEnum, Clone, Default, Debug,
-)]
+#[derive(clap::ValueEnum, Clone, Default, Debug)]
 enum ChatMode {
     #[default]
     General, // General chat bot mode
@@ -26,20 +24,22 @@ struct Args {
     mode: ChatMode,
 }
 
-
 fn read_user_input() -> String {
     let mut input = String::new();
-    std::io::stdin().read_line(&mut input).expect("Failed to read line");
+    std::io::stdin()
+        .read_line(&mut input)
+        .expect("Failed to read line");
     input
 }
 
 fn read_prompt_from_file(path: &str) -> String {
-    let mut file = std::fs::File::open(path).expect(format!("{}{}", "Failed to open file: ", path).as_str());
+    let mut file =
+        std::fs::File::open(path).expect(format!("{}{}", "Failed to open file: ", path).as_str());
     let mut contents = String::new();
-    file.read_to_string(&mut contents).expect("failed to read file");
+    file.read_to_string(&mut contents)
+        .expect("failed to read file");
     contents
 }
-
 
 fn clean_garbage_text(text: &str, garbage_patterns: Vec<&str>) -> String {
     let mut cleaned_text = String::from(text);
@@ -63,9 +63,18 @@ async fn chat_main(model: Llama, seed: String) {
     let mut last_generated = String::from("ROBOT:\n...\n");
     loop {
         println!("\n\nEnter a prompt: ");
-        let user_prompt = format!("{}\n{}\n{}{}\nROBOT:\n", seed, last_generated, USER_TURN_HEADER, read_user_input());
+        let user_prompt = format!(
+            "{}\n{}\n{}{}\nROBOT:\n",
+            seed,
+            last_generated,
+            USER_TURN_HEADER,
+            read_user_input()
+        );
         // println!("\n\n<DEBUG(prompt)>\n{}</DEBUG>\n\n", user_prompt);
-        let mut result = model.stream_text(&user_prompt).await.expect("Failed to stream text");
+        let mut result = model
+            .stream_text(&user_prompt)
+            .await
+            .expect("Failed to stream text");
         println!();
         last_generated = String::from(ROBOT_TURN_HEADER);
         while let Some(token) = result.next().await {
@@ -81,12 +90,15 @@ async fn chat_main(model: Llama, seed: String) {
 
 async fn task_specific_chat(model: Llama, seed: String) {
     let mut last_generated_history = Vec::new();
-     loop {
+    loop {
         println!("\n\nEnter a prompt: ");
         let user_input = read_user_input();
         let prompt = format!("{}\nQUESTION:\n\n{}\nANSWER:\n\n", seed, user_input);
-         // println!("\n\n<DEBUG(prompt)>\n{}</DEBUG>\n\n", prompt);
-        let mut result = model.stream_text(&prompt).await.expect("Failed to stream text");
+        // println!("\n\n<DEBUG(prompt)>\n{}</DEBUG>\n\n", prompt);
+        let mut result = model
+            .stream_text(&prompt)
+            .await
+            .expect("Failed to stream text");
         println!();
         let mut last_generated = String::from("ROBOT:\n");
         while let Some(token) = result.next().await {
@@ -115,7 +127,6 @@ async fn main() {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
- **feat: LLaMA model wrapped with seed and user prompt**
- **feat: busy-loop bigram model + seed**
- **feat: change to new_chat**
- **feat: two chat modes**
- **feat: clean garbage - dont let model play more then his turn in the conversation**
- **feat: make user impersonation regex multiline, squash linebreaks in output**
- **feat: test text garbage cleaning**
- **test: test text squashing**
- **test: read seed prompt**
- **test: test seed**
- **style: cargo fmt**
